### PR TITLE
Multiple fixes

### DIFF
--- a/examples/winepath.rs
+++ b/examples/winepath.rs
@@ -29,11 +29,18 @@ fn main() {
     };
 
     let config = WineConfig::from_env().unwrap();
-    println!("{}", match action {
-        Action::ToUnix => config.to_native_path(path).unwrap().to_string_lossy().to_string(),
-        Action::ToWindows => {
-            let path = std::fs::canonicalize(path).unwrap();
-            config.to_wine_path(path).unwrap().to_string()
+    println!(
+        "{}",
+        match action {
+            Action::ToUnix => config
+                .to_native_path(path)
+                .unwrap()
+                .to_string_lossy()
+                .to_string(),
+            Action::ToWindows => {
+                let path = std::fs::canonicalize(path).unwrap();
+                config.to_wine_path(path).unwrap().to_string()
+            }
         }
-    })
+    )
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,8 +58,7 @@ impl Display for WinePathError {
     }
 }
 
-impl std::error::Error for WinePathError {
-}
+impl std::error::Error for WinePathError {}
 
 fn default_wineprefix() -> Option<PathBuf> {
     std::env::var_os("HOME").map(PathBuf::from).map(|mut home| {
@@ -103,8 +102,8 @@ fn create_drive_cache(prefix: &NativePath) -> DriveCache {
     let drives_dir = prefix.join("dosdevices");
     let mut drive_cache = DriveCache::default();
 
-    for letter in 'a' as u8..='z' as u8 {
-        let drive_name = [letter, ':' as u8];
+    for letter in b'a'..=b'z' {
+        let drive_name = [letter, b':'];
         let drive_name = std::str::from_utf8(&drive_name).unwrap();
         let drive_dir = drives_dir.join(drive_name);
         if let Ok(target) = drive_dir.read_link() {
@@ -209,7 +208,7 @@ impl WineConfig {
         let index = drive_to_index(drive_letter);
         if let Some(native_root) = self.drive_cache[index].as_ref() {
             let mut path = native_root.to_path_buf();
-            for part in full_path[2..].split(r"\") {
+            for part in full_path[2..].split('\\') {
                 path.push(part);
             }
             Ok(path)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,9 @@ fn create_drive_cache(prefix: &NativePath) -> DriveCache {
         let drive_name = std::str::from_utf8(&drive_name).unwrap();
         let drive_dir = drives_dir.join(drive_name);
         if let Ok(target) = drive_dir.read_link() {
-            drive_cache[drive_to_index(char::from(letter))] = Some(drives_dir.join(target));
+            if let Ok(resolved_path) = drives_dir.join(target).canonicalize() {
+                drive_cache[drive_to_index(char::from(letter))] = Some(resolved_path);
+            }
         }
     }
     drive_cache


### PR DESCRIPTION
In this PR, I have proposed two minor fixes:

1. When I was doing one of my projects, I found out the path this crate converted to was correct but was not the best answer. This was due to `drive_dir.read_link()` returned a relative path `../` and my path was canonicalized beforehand, so it failed to resolve it to the best drive number.
2. I ran this crate through `cargo` with `cargo clippy` and fixed all the code style and format issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/goto-bus-stop/winepath/1)
<!-- Reviewable:end -->
